### PR TITLE
chore(migrate): migrate this tap to gitguardian/tap

### DIFF
--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -1,0 +1,3 @@
+{
+    "ggshield": "gitguardian/tap"
+}


### PR DESCRIPTION
In this MR, we lay the ground for transitioning to a unique central tap for all GitGuardian's tools.
This MR will add a redirection to `gitguardian/tap` in case someone tries to install ggshield from this tap.  
A dedicated message will be printed with dedicated instructions :

> ==> Searching for similarly named formulae...
Error: No similarly named formulae found.
It was migrated from gitguardian/ggshield to gitguardian/tap.
You can access it again by running:
  brew tap gitguardian/tap
And then you can install it by running:
  brew install ggshield