### PR TITLE
chore: migrate to homebrew core tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
+![Deprecated](https://img.shields.io/badge/status-deprecated-red)
+
 # [Deprecated] [GitGuardian Shield](https://github.com/GitGuardian/gg-shield) Homebrew tap
 
 [![PyPI](https://img.shields.io/pypi/v/ggshield?color=%231B2D55&style=for-the-badge)](https://pypi.org/project/ggshield/)
 [![Docker Image Version (latest semver)](https://img.shields.io/docker/v/gitguardian/ggshield?color=1B2D55&sort=semver&style=for-the-badge&label=Docker)](https://hub.docker.com/r/gitguardian/ggshield)
 [![License](https://img.shields.io/github/license/GitGuardian/gg-shield?color=%231B2D55&style=for-the-badge)](LICENSE)
 
-This [Homebrew](https://brew.sh) tap is **deprecated**, we recommend transitioning to [GitGuardian central tap](https://www.github.com/GitGuardian/homebrew-tap) to download all GitGuardian's products.  
+This repository used to host an Homebrew tap for [GGShield](http://github.com/GitGuardian/ggshield), but it is now deprecated.
+
+To install GGShield using Homebrew, use `brew install ggshield`.

--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -1,3 +1,3 @@
 {
-    "ggshield": "gitguardian/tap"
+  "ggshield": "homebrew/core"
 }


### PR DESCRIPTION
## Context
Similarly to https://github.com/GitGuardian/homebrew-tap/pull/8, we migrate ggshield formula to homebrew core formula.

This repo will then be archived as it won't be maintained anymore.

## Validation
Local validation on MacOS. 
### Before
```bash
brew uninstall ggshield
brew untap gitguardian/ggshield
brew install gitguardian/ggshield/ggshield
```
The install logs show the package is downloaded from ggshield tap, which redirects towards gitguardian tap (see last line):
```bash==> Tapping gitguardian/ggshield
Cloning into '/opt/homebrew/Library/Taps/gitguardian/homebrew-ggshield'...
remote: Enumerating objects: 222, done.
remote: Counting objects: 100% (62/62), done.
remote: Compressing objects: 100% (39/39), done.
remote: Total 222 (delta 36), reused 36 (delta 15), pack-reused 160 (from 1)
Receiving objects: 100% (222/222), 60.31 KiB | 2.51 MiB/s, done.
Resolving deltas: 100% (91/91), done.
Tapped (16 files, 77.6KB).
==> Fetching dependencies for gitguardian/tap/ggshield: python@3.13
```
### After
```bash
brew uninstall ggshield
brew untap gitguardian/ggshield # remove ggshield tap in case it was added
brew tap gitguardian/ggshield <replace-with-your-local-path>/homebrew-ggshield # add tap from local repo (this repo, on this branch) 
brew install gitguardian/ggshield/ggshield # install from tap
```
The install logs show the package is downloaded from core tap, as expected thanks to the migration.
```bash
==> Downloading https://ghcr.io/v2/homebrew/core/ggshield/manifests/1.38.1
```
Run `ggshield --version`=> works as expected.
